### PR TITLE
Add prop-types as a peer dependency and use it to replace React's PropTypes

### DIFF
--- a/examples/examples.js
+++ b/examples/examples.js
@@ -4,6 +4,6 @@ import ReactDOM from 'react-dom';
 import SpotifyPlayer from '../dist/SpotifyPlayer.js';
 
 ReactDOM.render(
-  <SpotifyPlayer uri="spotify:album:1TIUsv8qmYLpBEhvmBmyBk" size={{width: 800, height: 500}} theme="white" view="view" />,
+  <SpotifyPlayer uri="spotify:album:1TIUsv8qmYLpBEhvmBmyBk" size={{width: 800, height: 500}} theme="white" view="list" />,
   document.querySelector('.player')
 );

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "url": "https://github.com/alexanderwallin/react-spotify-player/issues"
   },
   "homepage": "https://github.com/alexanderwallin/react-spotify-player#readme",
+  "peerDependencies": {
+    "prop-types": "^15.5.10"
+  },
   "devDependencies": {
     "babel": "^6.3.13",
     "babel-cli": "^6.3.17",
@@ -40,6 +43,7 @@
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "^2.1.1",
     "eslint-plugin-react": "^3.12.0",
+    "prop-types": "^15.5.10",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",
     "watchify": "^3.6.1"

--- a/src/SpotifyPlayer.jsx
+++ b/src/SpotifyPlayer.jsx
@@ -7,9 +7,10 @@
  */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // Dimension prop type
-const dimensionPropType = React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.string]);
+const dimensionPropType = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
 
 // Size presets, defined by Spotify
 const sizePresets = {
@@ -35,22 +36,22 @@ const SpotifyPlayer = React.createClass({
   propTypes: {
 
     // Spotify URI
-    uri: React.PropTypes.string.isRequired,
+    uri: PropTypes.string.isRequired,
 
     // Size as either a preset or as custom dimensions
-    size: React.PropTypes.oneOfType([
-      React.PropTypes.oneOf(['large', 'compact']),
-      React.PropTypes.shape({
+    size: PropTypes.oneOfType([
+      PropTypes.oneOf(['large', 'compact']),
+      PropTypes.shape({
         width: dimensionPropType,
         height: dimensionPropType,
       }),
     ]),
 
     // View
-    view: React.PropTypes.oneOf(['list', 'coverart']),
+    view: PropTypes.oneOf(['list', 'coverart']),
 
     // Theme
-    theme: React.PropTypes.oneOf(['black', 'white']),
+    theme: PropTypes.oneOf(['black', 'white']),
   },
 
   getDefaultProps() {


### PR DESCRIPTION
Also fixes example warning on "view" prop

Addresses #3 
