### PR TITLE
iframe attributies

### DIFF
--- a/src/SpotifyPlayer.jsx
+++ b/src/SpotifyPlayer.jsx
@@ -43,12 +43,13 @@ class SpotifyPlayer extends Component {
 
     return (
       <iframe
+        title="Spotify"
         className="SpotifyPlayer"
         src={`https://embed.spotify.com/?uri=${uri}&view=${view}&theme=${theme}`}
         width={size.width}
         height={size.height}
         frameBorder="0"
-        allowTransparency="true"
+        allowtransparency="true"
       />
     );
   }


### PR DESCRIPTION
I got a warning from JEST today: React does not recognize the `allowTransparency` prop on a DOM element. 
Seems like in React 16, unknown attributes will be outputted in DOM: [DOM Attributes in React 16](https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html). I couldn't find the `allowTransparency`, in React supported HTML attributes, so I guess this is a better approach.

Also, I've added title property to the <iframe> to describe the iframe to screen readers. [https://dequeuniversity.com/rules/axe/1.1/frame-title](https://dequeuniversity.com/rules/axe/1.1/frame-title)